### PR TITLE
Remove GitHub links and use uncollapsed navigation

### DIFF
--- a/_themes/microej/static/css/microej.css
+++ b/_themes/microej/static/css/microej.css
@@ -610,7 +610,8 @@ div.rst-versions div.rst-other-versions a {
   color: #ee502e;
 }
 
-div.rst-other-versions > div.injected > dl:nth-child(3) {
+div.rst-other-versions > div.injected > dl:nth-child(3),
+div.rst-other-versions > div.injected > dl:nth-child(4) {
   display: none;
 }
 

--- a/conf.py
+++ b/conf.py
@@ -44,6 +44,7 @@ html_logo = '_themes/microej/static/logo-microej-white.png'
 html_favicon = '_themes/microej/static/logo-small.png'
 html_theme_options = {
     'logo_only': True,
+    'collapse_navigation': False,
 }
 html_show_sphinx = False
 


### PR DESCRIPTION
* Removes GitHub links from the flyout
* Doesn't "collapse" navigation links. This makes all of the navigation
  heading expandable, and also gives the user the ability to browse the
  navigation without navigating to a new page (by selecting the `[+]`
  icon)