### PR TITLE
M0137W-469 Update SDK requirements

### DIFF
--- a/overview/systemRequirements.rst
+++ b/overview/systemRequirements.rst
@@ -11,9 +11,12 @@ System Requirements
    - 2GB Disk
 
 - **Operating Systems :**
-   - Windows 10, Windows 8.1, Windows 8, Windows 7, Windows Vista or Windows XP SP3
-   - Linux distributions (tested on Ubuntu 12.04 and Ubuntu 14.04)
-   - Mac OS X (tested on version 10.10 Yosemite, 10.11 El Capitan, 10.14 Mojave)
+   - Windows 10, Windows 8.1 or Windows 8
+   - Linux distributions (tested on Ubuntu 16.04, 18.04 and 20.04)
+   - Mac OS X (tested on version 10.13 High Sierra, 10.14 Mojave)
+
+- **Java :**
+   - JRE or JDK 8 (OpenJDK or Oracle JDK)
 
 ..
    | Copyright 2008-2020, MicroEJ Corp. Content in this space is free 


### PR DESCRIPTION
Changes :
* Windows 7, Windows Vista and Windows XP SP3 removed since these editions reached their end of life
* Ubuntu versions set to the latest LTSs
* MacOS 10.10 Yosemite and 10.11 El Capitan removed since these editions reached their end of life
* MacOS 10.13 added since it is used by some MicroEJ employees
* Java requirements added