### PR TITLE
Fix incorrect link to CLI in mmm.rst

### DIFF
--- a/ApplicationDeveloperGuide/mmm.rst
+++ b/ApplicationDeveloperGuide/mmm.rst
@@ -249,7 +249,7 @@ Once the build kit is fully exported, the directory content shall look like:
 .. figure:: images/mmm_extract_build_kit.png
       :align: center
 
-To go further with headless builds, please consult `Tool-CommandLineBuild <https://github.com/MicroEJ/Tool-CommandLineBuild/README.rst>`_ for command line builds, 
+To go further with headless builds, please consult `Tool-CommandLineBuild <https://github.com/MicroEJ/Tool-CommandLineBuild>`_ for command line builds, 
 and this :ref:`tutorial <tutorial_setup_automated_build_using_jenkins_and_artifactory>` to setup MicroEJ modules build in continuous integration environments).
 
 


### PR DESCRIPTION
Point to root repository, github will render the README.rst properly (correct URL to README.rst is blob/...).