### PR TITLE
M0228J-91 Update download link of the CLI to the release 0.1.0

### DIFF
--- a/ApplicationDeveloperGuide/mmm.rst
+++ b/ApplicationDeveloperGuide/mmm.rst
@@ -333,7 +333,7 @@ Here is an example:
 Options defined in the [options] section are passed as system properties.
 
 .. warning:: 
-   - it is recommended to use quotes for names and values of options in the TOML file to avoid any issue with special characters
+   - it is mandatory to use quotes for values in the TOML file
    - if you use Windows paths, backslashes must be doubled in TOML file, for example ``C:\\Users\\johndoe\\ivysettings.xml``
 
 Options defined directly in the command line have a higher priority than the ones defined in the configuration file.

--- a/ApplicationDeveloperGuide/mmm.rst
+++ b/ApplicationDeveloperGuide/mmm.rst
@@ -277,7 +277,7 @@ Installation
 
 The steps to install MMM CLI are:
 
-- download `the MMM CLI archive <https://artifactory.cross/microej-cross5-snapshot/com/microej/cli/mmm-cli/1.0.0-RC202012011543/mmm-cli-1.0.0-RC202012011543.zip>`_
+- download `the MMM CLI archive <https://artifactory.cross/microej-cross5-release/com/microej/cli/mmm-cli/0.1.0/mmm-cli-0.1.0.zip>`_
 - extract the archive in any directory
 - add the ``bin`` directory of the created directory to the ``PATH`` environment variable of your machine
 - make sure the ``JAVA_HOME`` environment variable is set and points to a JRE/JDK installation or that ``java`` executable is in the ``PATH`` environment variable (Java 8 is required)


### PR DESCRIPTION
This PR updates the download link of the CLI to the release 0.1.0.
It also removes the quotes in TOML configuration file because of the bug https://youtrack.cross/issue/M0090IDE-3517.