### PR TITLE
remove the default conf when fetching architecture

### DIFF
--- a/PlatformDeveloperGuide/platformCreation.rst
+++ b/PlatformDeveloperGuide/platformCreation.rst
@@ -45,7 +45,7 @@ Once you downloaded a MicroEJ Architecture file, proceed with the following step
    A MicroEJ Architecture can be imported using MicroEJ Module Manager, by adding the following line in a :ref:`module description file <mmm_module_description>`:
    ::
 
-      <dependency org="com.microej.architecture.[ISA].[TOOLCHAIN]" name="[UID]" rev="[VERSION]" conf="default">
+      <dependency org="com.microej.architecture.[ISA].[TOOLCHAIN]" name="[UID]" rev="[VERSION]">
         <artifact name="[UID]" m:classifier="[USAGE]" ext="xpf"/>
       </dependency>
 


### PR DESCRIPTION
- useless with architectures uploaded to repository.microej.com up to
7.14.0 (without ivy.xml) - was not used in Wrover Platform
https://github.com/MicroEJ/Platform-Espressif-ESP-WROVER-KIT-V4.1/blob/master/ESP32-WROVER-Xtensa-FreeRTOS-configuration/module.ivy#L31
- useless and fails download of architecture 7.15.0 with ivy.xml and new
naming convention (no default conf)