### PR TITLE
M0078DDG-368 Make warnings fail the build

### DIFF
--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -1,8 +1,14 @@
-# Copyright 2008-2020, MicroEJ Corp. Content in this space is free for read and redistribute. Except if otherwise stated, modification is subject to MicroEJ Corp prior approval. 
+# Copyright 2008-2021, MicroEJ Corp. Content in this space is free for read and redistribute. Except if otherwise stated, modification is subject to MicroEJ Corp prior approval. 
 # MicroEJ is a trademark of MicroEJ Corp. All other trademarks and copyrights are the property of their respective owners.
+
+version: 2
 
 python:
   install:
     - requirements: requirements.txt
+
 formats:
   - pdf
+
+sphinx:
+  fail_on_warning: true

--- a/KernelDeveloperGuide/featuresCommunication.rst
+++ b/KernelDeveloperGuide/featuresCommunication.rst
@@ -10,11 +10,10 @@ Kernel Type Converters
 
 The shared interface mechanism allows to transfer an object instance of
 a Kernel type from one Feature to an other. To do that, the Kernel must
-register a new converter (See :ref:`kf.api.javadoc`
-``Kernel.addConverter()`` method).
+register a new converter (See ``Kernel.addConverter()`` method).
 
 ..
-   | Copyright 2008-2020, MicroEJ Corp. Content in this space is free 
+   | Copyright 2008-2021, MicroEJ Corp. Content in this space is free 
    for read and redistribute. Except if otherwise stated, modification 
    is subject to MicroEJ Corp prior approval.
    | MicroEJ is a trademark of MicroEJ Corp. All other trademarks and 

--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,6 @@
 # Makefile for Sphinx documentation
 #
-# Copyright 2019 MicroEJ Corp. All rights reserved.
+# Copyright 2019-2021 MicroEJ Corp. All rights reserved.
 # MicroEJ Corp. PROPRIETARY/CONFIDENTIAL. Use is subject to license terms.
 #
 
@@ -16,7 +16,7 @@ BUILDDIR      = _build
 # Internal variables.
 PAPEROPT_a4     = -D latex_paper_size=a4
 PAPEROPT_letter = -D latex_paper_size=letter
-ALLSPHINXOPTS   = -d $(BUILDDIR)/doctrees $(PAPEROPT_$(PAPER)) $(SPHINXOPTS) .
+ALLSPHINXOPTS   = -d $(BUILDDIR)/doctrees $(PAPEROPT_$(PAPER)) $(SPHINXOPTS) -W --keep-going .
 # the i18n builder cannot share the environment and doctrees with the others
 I18NSPHINXOPTS  = $(PAPEROPT_$(PAPER)) $(SPHINXOPTS) .
 

--- a/PlatformDeveloperGuide/ui.rst
+++ b/PlatformDeveloperGuide/ui.rst
@@ -1,4 +1,4 @@
-.. pack_gui:
+.. _pack_gui:
 
 ========================
 Graphical User Interface
@@ -25,7 +25,7 @@ Graphical User Interface
     uiSimulation
 
 ..
-   | Copyright 2008-2020, MicroEJ Corp. Content in this space is free 
+   | Copyright 2008-2021, MicroEJ Corp. Content in this space is free 
    for read and redistribute. Except if otherwise stated, modification 
    is subject to MicroEJ Corp prior approval.
    | MicroEJ is a trademark of MicroEJ Corp. All other trademarks and 

--- a/conf.py
+++ b/conf.py
@@ -10,7 +10,7 @@ import microej
 
 
 project = 'MicroEJ Documentation'
-copyright = '2008-2020, MicroEJ Corp. Content in this space is free for read and redistribute. Except if otherwise stated, modification is subject to MicroEJ Corp prior approval. MicroEJ is a trademark of MicroEJ Corp. All other trademarks and copyrights are the property of their respective owners.'
+copyright = '2008-2021, MicroEJ Corp. Content in this space is free for read and redistribute. Except if otherwise stated, modification is subject to MicroEJ Corp prior approval. MicroEJ is a trademark of MicroEJ Corp. All other trademarks and copyrights are the property of their respective owners.'
 author = 'MicroEJ'
 release = '1.0'
 


### PR DESCRIPTION
This PR changes the sphinx and readthedocs configuration to make the build fails if there are warnings. The change done in the Makefile allows to apply this change when building the doc locally. The change done in the file `.readthedocs.yml` allows to apply this change when building the doc on ReadTheDocs.

It also fixes the warnings to make the build pass. And I took this opportunity to update the copyright.