### PR TITLE
M0228J-148 Exclude Number.toString from supported methods

### DIFF
--- a/ApplicationDeveloperGuide/js/builtin.rst
+++ b/ApplicationDeveloperGuide/js/builtin.rst
@@ -126,7 +126,7 @@ Number
 - NaN
 - NEGATIVE_INFINITY
 - POSITIVE_INFINITY
-- toString ( [ radix ] )
+- **[excluded]** toString ( [ radix ] )
 - **[excluded]** toLocaleString()
 - valueOf ( )
 - **[excluded]** toFixed (fractionDigits)


### PR DESCRIPTION
Exclude Number.toString from supported methods since most of the tests on it fail.