### PR TITLE
Explain how to add the ivy `repository` configuration when embedding a module in a repository

### DIFF
--- a/ApplicationDeveloperGuide/repository.rst
+++ b/ApplicationDeveloperGuide/repository.rst
@@ -110,8 +110,20 @@ The ``artifacts`` configuration has to be derived with a new name as many times 
 Include a Module Repository
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-To add all the modules already included in an other module repository, 
-declare the module repository dependency using the ``repository`` configuration:
+To add all the modules already included in an other module repository,
+add the configuration ``repository`` if it does not exist:
+
+.. code-block:: xml
+   :emphasize-lines: 3
+
+   <configurations defaultconfmapping="default->default;provided->provided">
+      <!-- ... other configurations ... -->
+      <conf name="repository" visibility="private" description="Repository to be embedded in the repository" />
+
+   </configurations>
+
+Then declare the module repository dependency using the ``repository``
+configuration:
 
 .. code-block:: xml
    :emphasize-lines: 2


### PR DESCRIPTION
The ivy `repository` configuration is required as per the declaration
above, but this configuration is not (yet) created by default in the
skeleton.