### PR TITLE
M0078DDG-377 Modules natures fixes

### DIFF
--- a/ApplicationDeveloperGuide/moduleNatures.rst
+++ b/ApplicationDeveloperGuide/moduleNatures.rst
@@ -509,8 +509,8 @@ This plugin defines the following configuration properties:
      - Pattern of classes excluded from the code coverage analysis.
      - Not set
    * - microej.testsuite.properties.s3.cc.activated
-     - When this property is set to true, the code coverage analysis is disabled.
-     - Not set
+     - When this property is set to true, the code coverage analysis is enabled.
+     - ``true``
    * - test.run.excludes.pattern
      - Pattern of classes excluded from the test suite execution.
      - Empty string (no test)

--- a/ApplicationDeveloperGuide/moduleNatures.rst
+++ b/ApplicationDeveloperGuide/moduleNatures.rst
@@ -205,9 +205,6 @@ This module nature defines the following dedicated configuration properties:
    * - bar.javadoc.dir
      - Path of the folder containing the generated javadoc.
      - ``${target}/javadoc``
-   * - bar.javadoc.stylesheet.file
-     - Path of the Stylesheet used for the generated Javadoc.
-     - Not set
    * - bar.notification.email.from
      - The email address used as the from address when sending the notification emails.
      - Not set


### PR DESCRIPTION
- Fix description and default value of microej.testsuite.properties.s3.cc.activated property
- Remove the property bar.javadoc.stylesheet.file for the Module Repostiory build type since it is not used
