### PR TITLE
fix the GUI tutorial title with a verb

### DIFF
--- a/Tutorials/getStartedWithGUI/index.rst
+++ b/Tutorials/getStartedWithGUI/index.rst
@@ -1,7 +1,7 @@
-.. _gettingstarted:
+.. _tutorial_get_started_with_gui:
 
-Getting Started With GUI 
-=========================
+Get Started With GUI 
+====================
 
 .. toctree::
    :maxdepth: 1


### PR DESCRIPTION
start with a verb like other tutorials

(https://github.com/MicroEJ/docs/pull/257#discussion_r671182038 : the
folder was correctly renamed)