### PR TITLE
M0078DDG-434 Remove unreleased features for Standalone Application nature

### DIFF
--- a/ApplicationDeveloperGuide/moduleNatures.rst
+++ b/ApplicationDeveloperGuide/moduleNatures.rst
@@ -298,8 +298,6 @@ This module nature inherits the configuration properties of the following plugin
 
 - :ref:`module_natures.plugins.compilation`
 - :ref:`module_natures.plugins.platform_loader`
-- :ref:`module_natures.plugins.testsuite`
-- :ref:`module_natures.plugins.artifact_checker`
 
 This module nature defines the following dedicated configuration properties:
 


### PR DESCRIPTION
This change removes the features Test Suite and Artifact Checker from the Standalone Application since the addition of this features has not been released yet.
This change must be rollbacked when the SDK 5.5.0 is released.