### PR TITLE
M0137W-616 Enable linkchecker and remove failing link

### DIFF
--- a/Tutorials/getStartedWithGUI/setup.rst
+++ b/Tutorials/getStartedWithGUI/setup.rst
@@ -4,8 +4,8 @@ Setup your Environment
 Prerequisites
 -------------
 
-- Supported Operating System: MICROEJ SDK runs on the following operating systems: Windows (7, 8, 8.1, 10), Linux, macos.
-- A Java™ Runtime Environment 8 is needed on your host computer for running MICROEJ SDK Dist. 21.03: `Download Java <https://www.java.com/en/download/manual.jsp>`__.
+The :ref:`MICROEJ SDK <sdk_install>` must be installed.
+Please check the :ref:`MICROEJ SDK requirements <system-requirements>`.
 
 Download and Install
 --------------------

--- a/conf.py
+++ b/conf.py
@@ -80,9 +80,11 @@ pygments_style = 'microej.MicroEJStyle'
 # ignoring Github links with anchors at linkcheck
 # linkcheck_ignore = [r'https?:\/\/github\.com\/.+#.+']
 
+linkcheck_timeout = 20
+
 # trigger linkcheck on build
-# import subprocess
-# if os.getenv("READTHEDOCS") == "True":
-#     print("RUNNING LINKCHECK")
-#     linkcheck_output = subprocess.check_output(["make", "linkcheck"], env={"PATH": os.environ["PATH"]},)
-#     print(linkcheck_output.decode(errors="ignore"))
+import subprocess
+if os.getenv("READTHEDOCS") == "True":
+    print("RUNNING LINKCHECK")
+    linkcheck_output = subprocess.check_output(["make", "linkcheck"], env={"PATH": os.environ["PATH"]},)
+    print(linkcheck_output.decode(errors="ignore"))


### PR DESCRIPTION
This change enables the linkchecker and removes the failing link : https://www.java.com/en/download/manual.jsp
This link seems correct but for some reasons it does not pass the linkchecker.

Also the linkchecker timeout has been set to 20 seconds to avoid to be stuck too much time on a failing link.