### PR TITLE
add a missing changelog line

### DIFF
--- a/PlatformDeveloperGuide/architectureChangelog.rst
+++ b/PlatformDeveloperGuide/architectureChangelog.rst
@@ -1019,7 +1019,7 @@ Tools
 Core Engine
 ~~~~~~~~~~~
 
--  Fixed allocation of the exact free memory in immortals heap
+-  Fixed ``OutOfMemoryError`` thrown when allocating an object of the size of free memory in immortals heap
 
 .. _soar-6:
 

--- a/PlatformDeveloperGuide/architectureChangelog.rst
+++ b/PlatformDeveloperGuide/architectureChangelog.rst
@@ -1016,6 +1016,11 @@ Tools
 [7.9.0] - 2018-09-20
 --------------------
 
+Core Engine
+~~~~~~~~~~~
+
+-  Fixed allocation of the exact free memory in immortals heap
+
 .. _soar-6:
 
 SOAR


### PR DESCRIPTION
found during an old architecture 6.x validation