### PR TITLE
fix usage of resident application

### DIFF
--- a/SDKUserGuide/sdkChangeLog.rst
+++ b/SDKUserGuide/sdkChangeLog.rst
@@ -192,11 +192,11 @@ MicroEJ Module Manager
 -  Updated ``firmware-multiapp`` to allow Virtual Devices for automatically launching a Sandboxed Application project in the SDK.
 -  Updated ``firmware-multiapp`` to automatically configure the Virtual Device Kernel UID when a Firmware is built.
 -  Fixed ``firmware-multiapp`` skeleton default dependencies with only modules available in MicroEJ Central Repository.
--  Fixed ``firmware-multiapp`` unexpected build error when no declared Resident Application.
+-  Fixed ``firmware-multiapp`` unexpected build error when no declared System Application.
 -  Fixed ``firmware-multiapp`` build which may fail an unexpected ``Unresolved Dependencies`` error the first time,
    for Kernel APIs module dependencies (configuration ``kernelapi``) or Virtual Device specific modules dependencies (configuration ``default-vd``).
 -  Fixed ``firmware-multiapp`` unexpected build error when no Application (``.wpk`` file) found in the dropins folder.
--  Fixed ``firmware-multiapp`` unexpected build error when no declared Resident Application.
+-  Fixed ``firmware-multiapp`` unexpected build error when no declared System Application.
 -  Fixed ``firmware-singleapp`` and ``firmware-multiapp`` skeletons wrong package name generation for the default Main class.
 -  Fixed ``artifact-repository`` changelog check for modules with a snapshot version.
 

--- a/glossary.rst
+++ b/glossary.rst
@@ -23,7 +23,7 @@ This glossary defines the technical terms upon which the `MICROEJ VEE (Virtual E
             A MicroEJ Sandboxed Application is a MicroEJ Application that can run over a MicroEJ Multi-Sandbox Firmware. It can be linked either statically or dynamically.
 
          System Application
-            A MicroEJ System Application is a MicroEJ Sandboxed Application that is statically linked to a MicroEJ Multi-Sandbox Firmware, as it is part of the initial image and cannot be removed.
+            A MicroEJ System Application (formerly called a Resident Application) is a MicroEJ Sandboxed Application that is statically linked to a MicroEJ Multi-Sandbox Firmware, as it is part of the initial image and cannot be removed.
 
          Kernel Application
             A MicroEJ Kernel Application is a MicroEJ Standalone Application that implements the ability to be extended to produce a MicroEJ Multi-Sandbox Firmware.


### PR DESCRIPTION
- indicate the previous name in glossary as it was widely used in the
past, especially in samples README and forum posts
- replace Resident application -> System application except in plugin
label (Firmware Linker)