### PR TITLE
Feature/java memory model

### DIFF
--- a/ApplicationDeveloperGuide/runtime.rst
+++ b/ApplicationDeveloperGuide/runtime.rst
@@ -108,6 +108,7 @@ SNI allows you to:
 
 -  Call a C function from a Java method.
 -  Access an Immortal array in a C function (see the :ref:`runtime_bon` to learn about immortal objects).
+-  Access Java base type arrays during the execution of the native function.
 
 SNI does not allow you to:
 

--- a/ApplicationDeveloperGuide/runtime.rst
+++ b/ApplicationDeveloperGuide/runtime.rst
@@ -17,6 +17,18 @@ This binary code is linked by a tool named :ref:`SOAR <soar>` before execution: 
 .. [2]
    Tim Lindholm & Frank Yellin, The Java™ Virtual Machine Specification, Second Edition, 1999
 
+.. _mjvm_javamemorymodel:
+
+Memory model
+------------
+
+MicroEJ Runtime comply with the standard Java Memory Model. For more details, have a look to this great article:
+`Java Memory Model
+ <https://jenkov.com/tutorials/java-concurrency/java-memory-model.html>`_.
+
+ Concurrent applications should follow the same Java concurrency rules at the exception that the current version of the MEJ32 is
+ not impacted by the visibility of shared objects, regardless of the hardware memory architecture.
+
 .. _runtime_core_libraries:
 
 Core Libraries

--- a/ApplicationDeveloperGuide/runtime.rst
+++ b/ApplicationDeveloperGuide/runtime.rst
@@ -23,11 +23,10 @@ Memory model
 ------------
 
 MicroEJ Runtime complies with the standard Java Memory Model. For more details, have a look to this great article:
-`Java Memory Model
- <https://jenkov.com/tutorials/java-concurrency/java-memory-model.html>`_.
+`Java Memory Model <https://jenkov.com/tutorials/java-concurrency/java-memory-model.html>`_.
 
- Concurrent applications should follow the same Java concurrency rules at the exception that the current version of the MEJ32 is
- not impacted by the visibility of shared objects, regardless of the hardware memory architecture.
+Concurrent applications should follow the same Java concurrency rules at the exception that the current version of the MEJ32 is
+not impacted by the visibility of shared objects, regardless of the hardware memory architecture.
 
 .. _runtime_core_libraries:
 

--- a/ApplicationDeveloperGuide/runtime.rst
+++ b/ApplicationDeveloperGuide/runtime.rst
@@ -22,7 +22,7 @@ This binary code is linked by a tool named :ref:`SOAR <soar>` before execution: 
 Memory model
 ------------
 
-MicroEJ Runtime comply with the standard Java Memory Model. For more details, have a look to this great article:
+MicroEJ Runtime complies with the standard Java Memory Model. For more details, have a look to this great article:
 `Java Memory Model
  <https://jenkov.com/tutorials/java-concurrency/java-memory-model.html>`_.
 
@@ -108,7 +108,7 @@ SNI allows you to:
 
 -  Call a C function from a Java method.
 -  Access an Immortal array in a C function (see the :ref:`runtime_bon` to learn about immortal objects).
--  Access Java base type arrays during the execution of the native function.
+-  Access regular Java base type arrays from a native function context.
 
 SNI does not allow you to:
 


### PR DESCRIPTION
Improve documentation on the MEJ32 Runtime:
- Explicit the compliance of the Java Memory Model (plus details on the visibility of shared objects)
- Explain the validity scope of the SNI access to Java base type arrays in native functions.