### PR TITLE
Fix installation URL

### DIFF
--- a/SDKUserGuide/install.rst
+++ b/SDKUserGuide/install.rst
@@ -3,7 +3,7 @@
 Download and Install
 ====================
 
-The SDK is available for download at https://developer.microej.com/get-started.
+The SDK is available for download at https://developer.microej.com/microej-sdk-software-development-kit.
 Check the :ref:`system-requirements` page for the list of supported environments.
 
 Once downloaded, execute the installer and follow the installation process.


### PR DESCRIPTION
Installation download has been moved to a new page. the previous linked page (getting started) no longer contains the download and installation instructions.