### PR TITLE
Add an option to edit cacerts

### DIFF
--- a/SDKUserGuide/mmm.rst
+++ b/SDKUserGuide/mmm.rst
@@ -892,8 +892,8 @@ Ask your System Administrator, or retrieve the SSL certificate and add it to the
 
 - on Linux/macOS
 
-  #. Open a terminal,
-  #. Make sure the JDK's ``bin`` folder is in the ``PATH`` environment variable,
+  #. Open a terminal.
+  #. Make sure the JDK's ``bin`` folder is in the ``PATH`` environment variable.
   #. Execute the following command::
 
       keytool -importcert -v -noprompt -trustcacerts -alias myAlias -file /path/to/the/certificate.pem -keystore /path/to/the/truststore -storepass changeit

--- a/SDKUserGuide/mmm.rst
+++ b/SDKUserGuide/mmm.rst
@@ -883,11 +883,11 @@ Ask your System Administrator, or retrieve the SSL certificate and add it to the
 
 - on Windows
 
-  #. Install `Keystore Explorer <http://keystore-explorer.org/downloads.html>`_,
+  #. Install `Keystore Explorer <http://keystore-explorer.org/downloads.html>`_.
   #. Start Keystore Explorer, and open file ``[JRE_HOME]/lib/security/cacerts`` or ``[JDK_HOME]/jre/lib/security/cacerts`` with the password ``changeit``.
-     You may not have the right to modify this file. Edit rights if needed before opening it,
-  #. Click on :guilabel:`Tools`, then :guilabel:`Import Trusted Certificate`,
-  #. Select your certificate,
+     You may not have the right to modify this file. Edit rights if needed before opening it or open Keystore Explorer with admin rights.
+  #. Click on :guilabel:`Tools`, then :guilabel:`Import Trusted Certificate`.
+  #. Select your certificate.
   #. Save the ``cacerts`` file.
 
 - on Linux/macOS


### PR DESCRIPTION
I propose to add a little detail on how to edit cacerts: it is also possible to change cacerts by opening Keystore Explorer with admin rights.