### PR TITLE
Mention explicitely the Compliance level required for MicroEJ applications

### DIFF
--- a/ApplicationDeveloperGuide/runtime.rst
+++ b/ApplicationDeveloperGuide/runtime.rst
@@ -11,7 +11,7 @@ MicroEJ allows to develop Applications in the `Java® Language Specification ver
 Basically, Java source code is compiled by the Java compiler [1]_ into the binary format specified in the JVM specification [2]_. 
 This binary code is linked by a tool named :ref:`SOAR <soar>` before execution: ``.class`` files and some other application-related files (see :ref:`Classpath <chapter.microej.classpath>` chapter) are linked to produce the final binary file that the :ref:`Core Engine <core_engine>` will execute.
 
-.. note:: Set the Compiler Compliance Level to 1.7 to ensure the bytecode produced by the Java compiler is compatible with MicroEJ. The Compliance Level can be changed from the IDE: :guilabel:`Window` > :guilabel:`Preferences` > :guilabel:`Java` > :guilabel:`Compiler`.
+.. note:: When opened in the SDK, make sure that the Compiler Compliance Level of your project is set to 1.7 to ensure the bytecode produced by the Java compiler is compatible with MicroEJ. The Compliance Level can be changed from the menu: :guilabel:`Window` > :guilabel:`Preferences` > :guilabel:`Java` > :guilabel:`Compiler`.
 
 .. [1]
    The JDT compiler from the Eclipse IDE.

--- a/ApplicationDeveloperGuide/runtime.rst
+++ b/ApplicationDeveloperGuide/runtime.rst
@@ -11,6 +11,8 @@ MicroEJ allows to develop Applications in the `Java® Language Specification ver
 Basically, Java source code is compiled by the Java compiler [1]_ into the binary format specified in the JVM specification [2]_. 
 This binary code is linked by a tool named :ref:`SOAR <soar>` before execution: ``.class`` files and some other application-related files (see :ref:`Classpath <chapter.microej.classpath>` chapter) are linked to produce the final binary file that the :ref:`Core Engine <core_engine>` will execute.
 
+.. note:: Set the Compiler Compliance Level to 1.7 to ensure the bytecode produced by the Java compiler is compatible with MicroEJ. The Compliance Level can be changed from the IDE: :guilabel:`Window` > :guilabel:`Preferences` > :guilabel:`Java` > :guilabel:`Compiler`.
+
 .. [1]
    The JDT compiler from the Eclipse IDE.
 


### PR DESCRIPTION
Though this is the default with latest skeleton, I still encounter issues from time to time by customers that creates projects with an old SDK (for example 4.1.5) or with an non-microej skeleton (for example `std-java`).

This can cause problem because the semantic is different between 1.7 and 1.8. See https://forum.microej.com/t/cannot-refer-to-the-non-final-local-variable-foo-defined-in-an-enclosing-scope/1221 for such instance.