### PR TITLE
Add abstraction layer section to Core VEE Porting guide

### DIFF
--- a/ApplicationDeveloperGuide/runtime.rst
+++ b/ApplicationDeveloperGuide/runtime.rst
@@ -35,7 +35,7 @@ Embedded Device Configuration (EDC)
 The Embedded Device Configuration specification defines the minimal
 standard runtime environment for embedded devices. 
 
-This MicroEJ module is always required in the build path of a MicroEJ project; 
+This module is always required in the build path of an Application project; 
 and all others libraries depend on it. This library provides a set of options.
 Refer to the chapter :ref:`application_options` which lists all available options.
 

--- a/ApplicationDeveloperGuide/runtime.rst
+++ b/ApplicationDeveloperGuide/runtime.rst
@@ -33,8 +33,13 @@ Embedded Device Configuration (EDC)
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 The Embedded Device Configuration specification defines the minimal
-standard runtime environment for embedded devices. It defines all
-default API packages:
+standard runtime environment for embedded devices. 
+
+This MicroEJ module is always required in the build path of a MicroEJ project; 
+and all others libraries depend on it. This library provides a set of options.
+Refer to the chapter :ref:`application_options` which lists all available options.
+
+It defines all default API packages:
 
 -  `java.io <https://repository.microej.com/javadoc/microej_5.x/apis/java/io/package-frame.html>`_
 -  `java.lang <https://repository.microej.com/javadoc/microej_5.x/apis/java/lang/package-frame.html>`_
@@ -53,6 +58,18 @@ default API packages:
    * - Module
      - https://repository.microej.com/modules/ej/api/edc/
 
+
+**Use**
+
+The `EDC API Module`_ must 
+be added to the :ref:`module.ivy <mmm_module_description>` of the Application 
+Project:
+
+::
+
+   <dependency org="ej.api" name="edc" rev="1.3.5"/>
+
+.. _EDC API Module: https://repository.microej.com/modules/ej/api/edc/
 
 .. _runtime_bon:
 
@@ -86,6 +103,16 @@ allows:
    * - Module
      - https://repository.microej.com/modules/ej/api/bon/
  
+**Use**
+
+Add the following dependency to the :ref:`module.ivy <mmm_module_description>` of the Application 
+Project to use the `BON API Module`_:
+
+::
+
+   <dependency org="ej.api" name="bon" rev="1.4.2"/>
+
+.. _BON API Module: https://repository.microej.com/modules/ej/api/bon/
 
 .. _runtime_sni:
 

--- a/VEEPortingGuide/coreEngine.rst
+++ b/VEEPortingGuide/coreEngine.rst
@@ -598,6 +598,13 @@ platform configuration file, check :guilabel:`Multi Applications` to install the
 Core Engine in "Multi-Sandbox" mode. Otherwise, the "Single
 application" mode is installed.
 
+Abstraction Layer
+=================
+
+MicroEJ Core Engine Abstraction Layer implementation can be found on `MicroEJ Github`_ for several RTOS.
+
+.. _MicroEJ Github: https://github.com/orgs/MicroEJ/repositories?q=AbstractionLayer-Core&type=all&language=&sort=
+
 .. _memory-considerations:
 
 Memory Considerations
@@ -637,27 +644,7 @@ The memory consumption of main Core Engine runtime elements are described in :re
 Use
 ===
 
-The `EDC API Module`_ must 
-be added to the :ref:`module.ivy <mmm_module_description>` of the Application 
-Project. This MicroEJ module is always required in the build path of a MicroEJ project; 
-and all others libraries depend on it. This library provides a set of options.
-Refer to the chapter :ref:`application_options` which lists all available options.
-
-::
-
-   <dependency org="ej.api" name="edc" rev="1.3.3"/>
-
-The `BON API Module`_
-must also be added to the :ref:`module.ivy <mmm_module_description>` of the 
-Application project in order to access the :ref:`[BON] library <runtime_bon>`.
-
-::
-
-   <dependency org="ej.api" name="bon" rev="1.4.0"/>
-
-
-.. _EDC API Module: https://repository.microej.com/modules/ej/api/edc/
-.. _BON API Module: https://repository.microej.com/modules/ej/api/bon/
+Refer to the :ref:`MicroEJ Runtime <runtime_core_libraries>` documentation.
 
 ..
    | Copyright 2008-2023, MicroEJ Corp. Content in this space is free 


### PR DESCRIPTION
- Add abstraction layer section to Core VEE Porting guide
- Move use section from Core VEE Porting guide  to Application Guide Runtime page