### PR TITLE
Front Panel's resolve in Worspace requires SDK 5.7.0 and Archi 8.0

### DIFF
--- a/SDKUserGuide/resolveDependenciesInWorkspace.rst
+++ b/SDKUserGuide/resolveDependenciesInWorkspace.rst
@@ -90,6 +90,10 @@ and is displayed in a window on the user's development machine when the applicat
 
 When a Front Panel project is opened in the workspace, it is automatically used at runtime when launching the Simulator.
 
+.. note::
+
+   This feature requires SDK version ``5.7.0`` or higher and Architecture version ``8.0`` or higher.
+
 If the workspace contains several Front Panel projects, they are all automatically used by the Simulator, which can very probably causes issues.
 You can select the Front Panel you want to use by closing all the other Front Panel projects.
 


### PR DESCRIPTION
https://docs.microej.com/en/feature-add_architecture_8_note_in_front_panel_resolveinworkspace_section/SDKUserGuide/resolveDependenciesInWorkspace.html#resolve-front-panel-in-workspace