### PR TITLE
add buildExecutable in the Application graph and fix veePort properties

### DIFF
--- a/SDK6UserGuide/graphApplicationModule.dot
+++ b/SDK6UserGuide/graphApplicationModule.dot
@@ -14,11 +14,13 @@ digraph mygraph {
     "checkModule" [fillcolor = "#f76241"]
     "loadVeePort" [fillcolor = "#f76241"]
     "loadApplicationConfiguration" [fillcolor = "#f76241"]
+    "loadExecutableConfiguration" [fillcolor = "#f76241"] 
     "loadTestApplicationConfiguration" [fillcolor = "#f76241"]
     "runOnSimulator" [fillcolor = "#f76241"]
     "debugOnSimulator" [fillcolor = "#f76241"]
     "testOnSimulator" [fillcolor = "#f76241"]
     "buildWPK" [fillcolor = "#f76241"]
+    "buildExecutable" [fillcolor = "#f76241"]
     "build" -> "check"
     "check" -> "test"
     "test" -> "testOnSimulator"
@@ -48,6 +50,9 @@ digraph mygraph {
     "check" -> "checkModule"
     "buildWPK" -> "jar"
     "buildWPK" -> "javadoc"
+    "buildExecutable" -> "test"
+    "buildExecutable" -> "loadExecutableConfiguration"
+    "loadExecutableConfiguration" -> "loadVeePort"
 
     subgraph cluster_legend {
         label="Legend";

--- a/SDK6UserGuide/moduleNatures.rst
+++ b/SDK6UserGuide/moduleNatures.rst
@@ -62,6 +62,7 @@ This plugin adds the following tasks to your project:
 - :ref:`sdk6_module_natures.tasks.loadTestApplicationConfiguration`
 - :ref:`sdk6_module_natures.tasks.testOnSimulator`
 - :ref:`sdk6_module_natures.tasks.checkModule`
+- :ref:`sdk6_module_natures.tasks.loadExecutableConfiguration`
 - :ref:`sdk6_module_natures.tasks.buildExecutable`
 - :ref:`sdk6_module_natures.tasks.buildWPK`
 
@@ -121,10 +122,10 @@ This task provides the following properties that can be defined in the ``microej
    * - Name
      - Description
      - Default    
-   * - ``veePortDir``
+   * - ``veePortDirs``
      - Path of the root folder of the VEE Port to use in the build.
      - Not set
-   * - ``veePortFile``
+   * - ``veePortFiles``
      - Path of the VEE Port file to use in the build. 
      - Not set
 
@@ -133,7 +134,7 @@ For example:
 .. code::
 
   microej {
-    veePortDir = "C:\\path\\to\\my\\veePort\\directory"
+    veePortDirs = listOf("C:\\path\\to\\my\\veePort\\directory")
   }
 
 .. _sdk6_module_natures.tasks.loadApplicationConfiguration:
@@ -310,6 +311,19 @@ For example:
   microej {
     checkers = "readme,license"
   }
+
+.. _sdk6_module_natures.tasks.loadExecutableConfiguration:
+
+loadExecutableConfiguration
+^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+**Description**: Loads the configuration to build the Executable of an Application.
+
+**Module Natures**:
+
+This task is used by the following module natures:
+
+- :ref:`sdk6_module_natures.application`
 
 .. _sdk6_module_natures.tasks.buildExecutable:
 


### PR DESCRIPTION
https://docs.microej.com/en/feature-microej-sdk-6-add-buildexecutable-in-application-graph/SDK6UserGuide/moduleNatures.html