### PR TITLE
fix links to forge.microej.commit

### DIFF
--- a/VEEPortingGuide/uiCco.rst
+++ b/VEEPortingGuide/uiCco.rst
@@ -165,8 +165,8 @@ The C Module `com.microej.clibrary.llimpl#microui-mimxrt595-evk`_ only gives an 
 
 .. note:: For more information, see the :ref:`migration notes<section_ui_migrationguide_13.6_mimxrt595evk>`.
 
-.. _com.microej.clibrary.llimpl#microui-vglite: https://forge.microej.com/artifactory/microej-developer-repository-release/com/microej/clibrary/llimpl/microui-vglite
-.. _com.microej.clibrary.llimpl#microui-mimxrt595-evk: https://forge.microej.com/artifactory/microej-developer-repository-release/com/microej/clibrary/llimpl/microui-mimxrt595-evk
+.. _com.microej.clibrary.llimpl#microui-vglite: https://forge.microej.com/artifactory/microej-developer-repository-release/com/microej/clibrary/llimpl/microui-vglite/
+.. _com.microej.clibrary.llimpl#microui-mimxrt595-evk: https://forge.microej.com/artifactory/microej-developer-repository-release/com/microej/clibrary/llimpl/microui-mimxrt595-evk/
 
 .. _section_ui_c_module_microui_nemagfx:
 
@@ -242,7 +242,7 @@ The following table describes the accelerated features:
 
 This C module is available on the :ref:`developer_repository`: `com.microej.clibrary.llimpl#microui-nemagfx`_.
 
-.. _com.microej.clibrary.llimpl#microui-nemagfx: https://forge.microej.com/artifactory/microej-developer-repository-release/com/microej/clibrary/llimpl/microui-nemagfx
+.. _com.microej.clibrary.llimpl#microui-nemagfx: https://forge.microej.com/artifactory/microej-developer-repository-release/com/microej/clibrary/llimpl/microui-nemagfx/
 
 Compatibility
 =============

--- a/VEEPortingGuide/vgImage.rst
+++ b/VEEPortingGuide/vgImage.rst
@@ -223,7 +223,7 @@ The MicroVG Font APIs are available in the class ``ej.microvg.`` `VectorImage`_.
 .. _ResourceVectorImage: https://repository.microej.com/javadoc/microej_5.x/apis/ej/microvg/ResourceVectorImage.html
 .. _ResourceVectorImage.loadImage(): https://repository.microej.com/javadoc/microej_5.x/apis/ej/microvg/ResourceVectorImage.html#loadImage-java.lang.String-
 .. _VectorGraphicsPainter: https://repository.microej.com/javadoc/microej_5.x/apis/ej/microvg/VectorGraphicsPainter.html
-.. _VectorImageLoader: https://forge.microej.com/artifactory/microej-developer-repository-release/ej/library/ui/vectorimage-loader
+.. _VectorImageLoader: 
 
 ..
    | Copyright 2008-2023, MicroEJ Corp. Content in this space is free 


### PR DESCRIPTION
Upgrade to artifactory 7 seems to require the trailing '/' for correct redirection