### PR TITLE
Fix code coverage option command line

### DIFF
--- a/SDK6UserGuide/runOnSimulator.rst
+++ b/SDK6UserGuide/runOnSimulator.rst
@@ -124,7 +124,7 @@ To generate the Code Coverage files (``.cc``), invoke the ``:runOnSimulator`` ta
 
 ::
 
-   gradle :runOnSimulator -Ds3.cc.thread.period=15 -Ds3.cc.activated=true
+   gradle :runOnSimulator -D"s3.cc.thread.period=15" -D"s3.cc.activated=true"
 
 *Option Name*: ``s3.cc.thread.period``
 


### PR DESCRIPTION
Fix code coverage option command line (add quotes) to make it run on Windows