### PR TITLE
Additional SystemProperties for s3 coverage w/ SDK6

### DIFF
--- a/SDK6UserGuide/testProject.rst
+++ b/SDK6UserGuide/testProject.rst
@@ -203,6 +203,7 @@ To generate the Code Coverage files (``.cc``) for each test, configure the test 
                   testTask.configure {
                      doFirst {
                         systemProperties["microej.testsuite.properties.s3.cc.activated"] = "true"
+                        systemProperties["microej.testsuite.properties.s3.cc.thread.period"] = "15"
                      }
                   }
                }


### PR DESCRIPTION
Addition of a second missing **SystemProperties** in S3 coverage setup, essential for code coverage report generation.