### PR TITLE
Retell that createVM and destroyVM should be called only once

### DIFF
--- a/VEEPortingGuide/coreEngine.rst
+++ b/VEEPortingGuide/coreEngine.rst
@@ -432,7 +432,12 @@ To restart the application, call again the ``SNI_startVM`` function (see the fol
 
    Please note that while the Core Engine supports restart, :ref:`MicroUI <section_microui>` does not. 
    Attempting to restart the Application on a VEE Port with UI support may result in undefined behavior.
-     
+
+
+.. note::
+
+   Please note that `SNI_createVM`` and ``SNI_destroyVM`` should only be called once. 
+   When restarting the Core Engine, don't call ``SNI_createVM`` or ``SNI_destroyVM`` before calling ``SNI_startVM`` again.
 
 .. _vm_dump:
 

--- a/VEEPortingGuide/coreEngine.rst
+++ b/VEEPortingGuide/coreEngine.rst
@@ -436,7 +436,7 @@ To restart the application, call again the ``SNI_startVM`` function (see the fol
 
 .. note::
 
-   Please note that `SNI_createVM`` and ``SNI_destroyVM`` should only be called once. 
+   Please note that ``SNI_createVM`` and ``SNI_destroyVM`` should only be called once. 
    When restarting the Core Engine, don't call ``SNI_createVM`` or ``SNI_destroyVM`` before calling ``SNI_startVM`` again.
 
 .. _vm_dump:


### PR DESCRIPTION
Even though it's explained above, when I looked at how to restart the core engine, I only looked at the `restart core engine` section, not the whole page.