### PR TITLE
Update ubsipd wsl

### DIFF
--- a/ApplicationDeveloperGuide/debuggerProxy.rst
+++ b/ApplicationDeveloperGuide/debuggerProxy.rst
@@ -277,7 +277,7 @@ VEE Debugger Proxy Options Summary
 Troubleshooting
 ===============
 
-You may encounter some command line issues if you try to run the proxy on Windows Powershell. 
+You may encounter some command line issues if you try to run the proxy on Windows PowerShell. 
 
 On Windows workstation, we recommend using ``CMD`` Command Prompt instead.
 

--- a/SDK6UserGuide/licenses.rst
+++ b/SDK6UserGuide/licenses.rst
@@ -307,11 +307,21 @@ To get more details on connected USB dongle(s), run the debug tool as following:
 #. Change directory to a Production VEE Port.
 #. Execute the command:
    
-   .. code:: console
+.. tabs::
 
-      java -Djava.library.path=resources/os/[OS_NAME] -jar licenseManager/licenseManagerUsbDongle.jar
+   .. tab:: Atchitecture v8.1.0 or higher
+   
+      .. code:: console
 
-   with ``OS_NAME`` set to ``Windows64`` for Windows OS, ``Linux64`` for Linux OS, ``Mac`` for macOS x86_64 (Intel chip) or ``MacA64`` for macOS aarch64 (M1 chip).
+            java -Djava.library.path=resources/os/[OS_NAME] -jar licenseManager/licenseManagerProduct.jar
+
+   .. tab:: Architecture v8.0.0 or lower 
+
+      .. code:: console
+
+            java -Djava.library.path=resources/os/[OS_NAME] -jar licenseManager/licenseManagerUsbDongle.jar
+
+with ``OS_NAME`` set to ``Windows64`` for Windows OS, ``Linux64`` for Linux OS, ``Mac`` for macOS x86_64 (Intel chip) or ``MacA64`` for macOS aarch64 (M1 chip).
 
 If your USB dongle has been properly activated, you should get the following output:
    
@@ -392,7 +402,7 @@ To use a USB dongle with WSL, you first need to install `usbipd` following the s
 
 First, check that WSL2 is installed on your system. If not, install it or update it following `Microsoft Documentation <https://learn.microsoft.com/fr-fr/windows/wsl/install>`__
 
-Then, you need install usbipd-win on Windows from `usbipd-win Github repository <https://github.com/dorssel/usbipd-win/releases>`__.
+Then, you need install usbipd-win v4.0.0 or higher on Windows from `usbipd-win Github repository <https://github.com/dorssel/usbipd-win/releases>`__.
 
 And then, install usbipd and update hardware database inside you WSL installation:
 
@@ -411,15 +421,16 @@ You then need to unplug and plug your dongle again before attaching the dongle t
 
   .. code-block:: console
 
-      usbipd.exe wsl attach --busid <BUSID>
+      usbipd.exe attach --wsl --busid <BUSID>
 
 The ``<BUSID>`` can be obtainted with the following powershell command:
 
   .. code-block:: console
 
-      usbipd wsl list
+      usbipd list
 
 .. note::
+
       You'll need to follow these steps each time you system is rebooted or the dongle is plugged/unplugged.
 
 .. _sdk6_production_license_troubleshooting:
@@ -471,13 +482,13 @@ Check that your dongle is attached to WSL from Powershell:
 
   .. code-block:: console
 
-      usbipd wsl list
+      usbipd list
 
 You should have a  line saying ``Attached - Ubuntu``:
 
   .. code-block:: console
 
-      PS C:\Users\sdkuser> usbipd.exe wsl list
+      PS C:\Users\sdkuser> usbipd.exe list
       BUSID  VID:PID    DEVICE                                                        STATE
       2-1    096e:0006  USB Input Device                                              Attached - Ubuntu
       2-6    0c45:6a10  Integrated Webcam                                             Not attached

--- a/SDK6UserGuide/licenses.rst
+++ b/SDK6UserGuide/licenses.rst
@@ -398,9 +398,9 @@ USB Dongle with WSL
 .. note::
    The following steps have been tested on WSL2 with Ubuntu 22.04.2 LTS.
 
-To use a USB dongle with WSL, you first need to install `usbipd` following the steps described in `Microsoft WSL documentation <https://learn.microsoft.com/fr-fr/windows/wsl/connect-usb#install-the-usbipd-win-project>`__:
+To use a USB dongle with WSL, you first need to install `usbipd` following the steps described in `Microsoft WSL documentation <https://learn.microsoft.com/en-us/windows/wsl/connect-usb#install-the-usbipd-win-project>`__:
 
-First, check that WSL2 is installed on your system. If not, install it or update it following `Microsoft Documentation <https://learn.microsoft.com/fr-fr/windows/wsl/install>`__
+First, check that WSL2 is installed on your system. If not, install it or update it following `Microsoft Documentation <https://learn.microsoft.com/en-us/windows/wsl/install>`__
 
 Then, you need install usbipd-win v4.0.0 or higher on Windows from `usbipd-win Github repository <https://github.com/dorssel/usbipd-win/releases>`__.
 

--- a/SDK6UserGuide/licenses.rst
+++ b/SDK6UserGuide/licenses.rst
@@ -461,9 +461,9 @@ Open a bash terminal in your WSL instance, and check the USB dongle is successfu
 
 You should see your USB dongle connected with ``ID 096e:0006``:
 
-.. code:: console
+.. code-block:: console
+   :emphasize-lines: 2
 
-      :emphasize-lines: 2
       Bus 002 Device 001: ID 1d6b:0003 Linux Foundation 3.0 root hub
       Bus 001 Device 002: ID 096e:0006 Feitian Technologies, Inc. HID Dongle (for OEMs - manufacturer string is "OEM")
       Bus 001 Device 001: ID 1d6b:0002 Linux Foundation 2.0 root hub

--- a/SDK6UserGuide/licenses.rst
+++ b/SDK6UserGuide/licenses.rst
@@ -321,7 +321,7 @@ To get more details on connected USB dongle(s), run the debug tool as following:
 
             java -Djava.library.path=resources/os/[OS_NAME] -jar licenseManager/licenseManagerUsbDongle.jar
 
-with ``OS_NAME`` set to ``Windows64`` for Windows OS, ``Linux64`` for Linux OS, ``Mac`` for macOS x86_64 (Intel chip) or ``MacA64`` for macOS aarch64 (M1 chip).
+with ``OS_NAME`` set to ``Windows64`` for Windows OS, ``Linux64`` for Linux OS, ``Mac`` for macOS x86_64 (Intel chip) or ``MacA64`` for macOS aarch64 (Apple Silicon chip).
 
 If your USB dongle has been properly activated, you should get the following output:
    

--- a/SDK6UserGuide/licenses.rst
+++ b/SDK6UserGuide/licenses.rst
@@ -417,17 +417,56 @@ Add the udev rule described in :ref:`production_license_linux`, and restart udev
 
       sudo /etc/init.d/udev restart
 
-You then need to unplug and plug your dongle again before attaching the dongle to WSL from powershell:
+Ensure your USB dongle is plugged, then start a Powershell terminal in administrator mode.
+
+List the connected devices with the following command:
 
   .. code-block:: console
 
-      usbipd.exe attach --wsl --busid <BUSID>
+      usbipd.exe list
 
-The ``<BUSID>`` can be obtainted with the following powershell command:
+You should see your USB dongle connected with ``VID:PID==096e:0006``:
+
+.. code-block:: console   
+   :emphasize-lines: 9
+
+      PS C:\Users\user> usbipd list
+      Connected:
+      BUSID  VID:PID    DEVICE                                                        STATE
+      2-6    0c45:674c  Integrated Webcam, Integrated IR Webcam, USB DFU              Not shared
+      2-8    0a5c:5843  Dell ControlVault w/ Fingerprint Touch Sensor, Microsoft ...  Not shared
+      2-10   8087:0033  Intel(R) Wireless Bluetooth(R)                                Not shared
+      3-1    0bda:8153  Realtek USB GbE Family Controller                             Not shared
+      4-6    413c:c010  Dell DA310                                                    Not shared
+      6-4    096e:0006  USB Input Device                                              Not shared
+      6-6    046d:0819  USB Video Device, USB Audio Device                            Not shared
+      7-1    045e:0084  USB Input Device                                              Not shared
+      7-2    04d9:1400  USB Input Device                                              Not shared
+      7-3    10d5:55a2  USB Input Device                                              Not shared
+
+Here the ``BUSID`` is ``6-4``.
+
+Bind and attach the dongle to WSL:
 
   .. code-block:: console
 
-      usbipd list
+      usbipd.exe bind --busid <BUSID>
+      usbipd.exe attach --wsl  --busid <BUSID>
+
+Open a bash terminal in your WSL instance, and check the USB dongle is successfully mounted with the following command:
+
+  .. code-block:: console
+
+      lsusb
+
+You should see your USB dongle connected with ``ID 096e:0006``:
+
+.. code:: console
+
+      :emphasize-lines: 2
+      Bus 002 Device 001: ID 1d6b:0003 Linux Foundation 3.0 root hub
+      Bus 001 Device 002: ID 096e:0006 Feitian Technologies, Inc. HID Dongle (for OEMs - manufacturer string is "OEM")
+      Bus 001 Device 001: ID 1d6b:0002 Linux Foundation 2.0 root hub
 
 .. note::
 

--- a/SDK6UserGuide/licenses.rst
+++ b/SDK6UserGuide/licenses.rst
@@ -521,7 +521,7 @@ Check that your dongle is attached to WSL from Powershell:
 
   .. code-block:: console
 
-      usbipd list
+      usbipd.exe list
 
 You should have a  line saying ``Attached - Ubuntu``:
 

--- a/SDK6UserGuide/licenses.rst
+++ b/SDK6UserGuide/licenses.rst
@@ -417,7 +417,7 @@ Add the udev rule described in :ref:`production_license_linux`, and restart udev
 
       sudo /etc/init.d/udev restart
 
-Ensure your USB dongle is plugged, then start a Powershell terminal in administrator mode.
+Ensure your USB dongle is plugged, then start a PowerShell terminal in administrator mode.
 
 List the connected devices with the following command:
 
@@ -517,7 +517,7 @@ and add the USB dongle in the :guilabel:`USB Devices Filters` list.
 WSL Troubleshooting
 """""""""""""""""""
 
-Check that your dongle is attached to WSL from Powershell:
+Check that your dongle is attached to WSL from PowerShell:
 
   .. code-block:: console
 
@@ -547,7 +547,7 @@ In you WSL console, the dongle must also be recognized. Ckeck by using ``lsusb``
 This might not be sufficient. If you're still facing license issues, restart udev, abd attach your dongle to WSL once again.
 
 .. note::
-   Hibernation may have unattached your dongle. Reload udev, unplug/plug your dongle and attach it from powershell.
+   Hibernation may have unattached your dongle. Reload udev, unplug/plug your dongle and attach it from PowerShell.
 
 Remote USB Dongle Connection
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~

--- a/SDK6UserGuide/licenses.rst
+++ b/SDK6UserGuide/licenses.rst
@@ -309,7 +309,7 @@ To get more details on connected USB dongle(s), run the debug tool as following:
    
 .. tabs::
 
-   .. tab:: Atchitecture v8.1.0 or higher
+   .. tab:: Architecture v8.1.0 or higher
    
       .. code:: console
 

--- a/SDK6UserGuide/licenses.rst
+++ b/SDK6UserGuide/licenses.rst
@@ -415,7 +415,7 @@ Add the udev rule described in :ref:`production_license_linux`, and restart udev
 
    .. code-block:: console
 
-      /etc/init.d/udev restart
+      sudo /etc/init.d/udev restart
 
 You then need to unplug and plug your dongle again before attaching the dongle to WSL from powershell:
 

--- a/SDKUserGuide/licenses.rst
+++ b/SDKUserGuide/licenses.rst
@@ -440,13 +440,13 @@ Add the udev rule described in :ref:`production_license_linux`, and restart udev
 
       /etc/init.d/udev restart
 
-You then need to unplug and plug your dongle again before attaching the dongle to WSL from powershell:
+You then need to unplug and plug your dongle again before attaching the dongle to WSL from PowerShell:
 
   .. code-block:: console
 
       usbipd.exe attach --wsl --busid <BUSID>
 
-The ``<BUSID>`` can be obtainted with the following powershell command:
+The ``<BUSID>`` can be obtainted with the following PowerShell command:
 
   .. code-block:: console
 
@@ -500,7 +500,7 @@ and add the USB dongle in the :guilabel:`USB Devices Filters` list.
 WSL Troubleshooting
 """""""""""""""""""
 
-Check that your dongle is attached to WSL from Powershell:
+Check that your dongle is attached to WSL from PowerShell:
 
   .. code-block:: console
 
@@ -530,7 +530,7 @@ In you WSL console, the dongle must also be recognized. Ckeck by using ``lsusb``
 This might not be sufficient. If you're still facing license issues, restart udev, abd attach your dongle to WSL once again.
 
 .. note::
-   Hibernation may have unattached your dongle. Reload udev, unplug/plug your dongle and attach it from powershell.
+   Hibernation may have unattached your dongle. Reload udev, unplug/plug your dongle and attach it from PowerShell.
 
 Dongle not detected in the licenses screen
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~

--- a/SDKUserGuide/licenses.rst
+++ b/SDKUserGuide/licenses.rst
@@ -344,7 +344,7 @@ To get more details on connected USB dongle(s), run the debug tool as following:
 
             java -Djava.library.path=resources/os/[OS_NAME] -jar licenseManager/licenseManagerUsbDongle.jar
 
-with ``OS_NAME`` set to ``Windows64`` for Windows OS, ``Linux64`` for Linux OS, ``Mac`` for macOS x86_64 (Intel chip) or ``MacA64`` for macOS aarch64 (M1 chip).
+with ``OS_NAME`` set to ``Windows64`` for Windows OS, ``Linux64`` for Linux OS, ``Mac`` for macOS x86_64 (Intel chip) or ``MacA64`` for macOS aarch64 (Apple Silicon chip).
 
 If your USB dongle has been properly activated, you should get the following output:
    

--- a/SDKUserGuide/licenses.rst
+++ b/SDKUserGuide/licenses.rst
@@ -484,9 +484,9 @@ Open a bash terminal in your WSL instance, and check the USB dongle is successfu
 
 You should see your USB dongle connected with ``ID 096e:0006``:
 
-.. code:: console
+.. code-block:: console
+   :emphasize-lines: 2
 
-      :emphasize-lines: 2
       Bus 002 Device 001: ID 1d6b:0003 Linux Foundation 3.0 root hub
       Bus 001 Device 002: ID 096e:0006 Feitian Technologies, Inc. HID Dongle (for OEMs - manufacturer string is "OEM")
       Bus 001 Device 001: ID 1d6b:0002 Linux Foundation 2.0 root hub

--- a/SDKUserGuide/licenses.rst
+++ b/SDKUserGuide/licenses.rst
@@ -438,21 +438,61 @@ Add the udev rule described in :ref:`production_license_linux`, and restart udev
 
    .. code-block:: console
 
-      /etc/init.d/udev restart
+      sudo /etc/init.d/udev restart
 
-You then need to unplug and plug your dongle again before attaching the dongle to WSL from PowerShell:
+Ensure your USB dongle is plugged, then start a PowerShell terminal in administrator mode.
 
-  .. code-block:: console
-
-      usbipd.exe attach --wsl --busid <BUSID>
-
-The ``<BUSID>`` can be obtainted with the following PowerShell command:
+List the connected devices with the following command:
 
   .. code-block:: console
 
-      usbipd list
+      usbipd.exe list
+
+You should see your USB dongle connected with ``VID:PID==096e:0006``:
+
+.. code-block:: console   
+   :emphasize-lines: 9
+
+      PS C:\Users\user> usbipd list
+      Connected:
+      BUSID  VID:PID    DEVICE                                                        STATE
+      2-6    0c45:674c  Integrated Webcam, Integrated IR Webcam, USB DFU              Not shared
+      2-8    0a5c:5843  Dell ControlVault w/ Fingerprint Touch Sensor, Microsoft ...  Not shared
+      2-10   8087:0033  Intel(R) Wireless Bluetooth(R)                                Not shared
+      3-1    0bda:8153  Realtek USB GbE Family Controller                             Not shared
+      4-6    413c:c010  Dell DA310                                                    Not shared
+      6-4    096e:0006  USB Input Device                                              Not shared
+      6-6    046d:0819  USB Video Device, USB Audio Device                            Not shared
+      7-1    045e:0084  USB Input Device                                              Not shared
+      7-2    04d9:1400  USB Input Device                                              Not shared
+      7-3    10d5:55a2  USB Input Device                                              Not shared
+
+Here the ``BUSID`` is ``6-4``.
+
+Bind and attach the dongle to WSL:
+
+  .. code-block:: console
+
+      usbipd.exe bind --busid <BUSID>
+      usbipd.exe attach --wsl  --busid <BUSID>
+
+Open a bash terminal in your WSL instance, and check the USB dongle is successfully mounted with the following command:
+
+  .. code-block:: console
+
+      lsusb
+
+You should see your USB dongle connected with ``ID 096e:0006``:
+
+.. code:: console
+
+      :emphasize-lines: 2
+      Bus 002 Device 001: ID 1d6b:0003 Linux Foundation 3.0 root hub
+      Bus 001 Device 002: ID 096e:0006 Feitian Technologies, Inc. HID Dongle (for OEMs - manufacturer string is "OEM")
+      Bus 001 Device 001: ID 1d6b:0002 Linux Foundation 2.0 root hub
 
 .. note::
+
       You'll need to follow these steps each time you system is rebooted or the dongle is plugged/unplugged.
 
 .. _production_license_troubleshooting:
@@ -504,7 +544,7 @@ Check that your dongle is attached to WSL from PowerShell:
 
   .. code-block:: console
 
-      usbipd list
+      usbipd.exe list
 
 You should have a  line saying ``Attached - Ubuntu``:
 

--- a/SDKUserGuide/licenses.rst
+++ b/SDKUserGuide/licenses.rst
@@ -421,9 +421,9 @@ USB Dongle with WSL
 .. note::
    The following steps have been tested on WSL2 with Ubuntu 22.04.2 LTS.
 
-To use a USB dongle with WSL, you first need to install `usbipd` following the steps described in `Microsoft WSL documentation <https://learn.microsoft.com/fr-fr/windows/wsl/connect-usb#install-the-usbipd-win-project>`__:
+To use a USB dongle with WSL, you first need to install `usbipd` following the steps described in `Microsoft WSL documentation <https://learn.microsoft.com/en-us/windows/wsl/connect-usb#install-the-usbipd-win-project>`__:
 
-First, check that WSL2 is installed on your system. If not, install it or update it following `Microsoft Documentation <https://learn.microsoft.com/fr-fr/windows/wsl/install>`__
+First, check that WSL2 is installed on your system. If not, install it or update it following `Microsoft Documentation <https://learn.microsoft.com/en-us/windows/wsl/install>`__
 
 Then, you need install usbipd-win v4.0.0 or higher on Windows from `usbipd-win Github repository <https://github.com/dorssel/usbipd-win/releases>`__.
 

--- a/SDKUserGuide/licenses.rst
+++ b/SDKUserGuide/licenses.rst
@@ -330,11 +330,21 @@ To get more details on connected USB dongle(s), run the debug tool as following:
 #. Change directory to a Production VEE Port.
 #. Execute the command:
    
-   .. code:: console
+.. tabs::
 
-      java -Djava.library.path=resources/os/[OS_NAME] -jar licenseManager/licenseManagerUsbDongle.jar
+   .. tab:: Architecture v8.1.0 or higher
+   
+      .. code:: console
 
-   with ``OS_NAME`` set to ``Windows64`` for Windows OS, ``Linux64`` for Linux OS, ``Mac`` for macOS x86_64 (Intel chip) or ``MacA64`` for macOS aarch64 (M1 chip).
+            java -Djava.library.path=resources/os/[OS_NAME] -jar licenseManager/licenseManagerProduct.jar
+
+   .. tab:: Architecture v8.0.0 or lower
+
+      .. code:: console
+
+            java -Djava.library.path=resources/os/[OS_NAME] -jar licenseManager/licenseManagerUsbDongle.jar
+
+with ``OS_NAME`` set to ``Windows64`` for Windows OS, ``Linux64`` for Linux OS, ``Mac`` for macOS x86_64 (Intel chip) or ``MacA64`` for macOS aarch64 (M1 chip).
 
 If your USB dongle has been properly activated, you should get the following output:
    
@@ -415,7 +425,7 @@ To use a USB dongle with WSL, you first need to install `usbipd` following the s
 
 First, check that WSL2 is installed on your system. If not, install it or update it following `Microsoft Documentation <https://learn.microsoft.com/fr-fr/windows/wsl/install>`__
 
-Then, you need install usbipd-win on Windows from `usbipd-win Github repository <https://github.com/dorssel/usbipd-win/releases>`__.
+Then, you need install usbipd-win v4.0.0 or higher on Windows from `usbipd-win Github repository <https://github.com/dorssel/usbipd-win/releases>`__.
 
 And then, install usbipd and update hardware database inside you WSL installation:
 
@@ -434,13 +444,13 @@ You then need to unplug and plug your dongle again before attaching the dongle t
 
   .. code-block:: console
 
-      usbipd.exe wsl attach --busid <BUSID>
+      usbipd.exe attach --wsl --busid <BUSID>
 
 The ``<BUSID>`` can be obtainted with the following powershell command:
 
   .. code-block:: console
 
-      usbipd wsl list
+      usbipd list
 
 .. note::
       You'll need to follow these steps each time you system is rebooted or the dongle is plugged/unplugged.
@@ -494,13 +504,13 @@ Check that your dongle is attached to WSL from Powershell:
 
   .. code-block:: console
 
-      usbipd wsl list
+      usbipd list
 
 You should have a  line saying ``Attached - Ubuntu``:
 
   .. code-block:: console
 
-      PS C:\Users\sdkuser> usbipd.exe wsl list
+      PS C:\Users\sdkuser> usbipd.exe list
       BUSID  VID:PID    DEVICE                                                        STATE
       2-1    096e:0006  USB Input Device                                              Attached - Ubuntu
       2-6    0c45:6a10  Integrated Webcam                                             Not attached


### PR DESCRIPTION
Update instructions to configure USB Dongle in WSL. 
According to https://learn.microsoft.com/en-us/windows/wsl/connect-usb#install-the-usbipd-win-project, commands have changed since usbipd-win 4.0.0

![image](https://github.com/user-attachments/assets/4fc8976d-44fa-4ee0-aa07-f394c2b07deb)
