### PR TITLE
Clarify 'KF RAM Control: Managed Heap Configuration'

### DIFF
--- a/KernelDeveloperGuide/kf.rst
+++ b/KernelDeveloperGuide/kf.rst
@@ -727,10 +727,10 @@ The following APIs allow to configure the Managed Heap usage:
   
 Especially, allocations from Features will fail (throw an OutOfMemoryError):
 
-    - when the feature-specific limit is reached, before the Managed heap is full;
-    - when the Managed heap is full, before the feature-specific limit is reached;
-    - when the Managed heap is almost full, so that the allocation would exceed the amount of memory that can be
-      allocated for Features (i.e. total Managed heap size minus memory reserved for Kernel).
+- when the feature-specific limit is reached, before the Managed heap is full;
+- when the Managed heap is full, before the feature-specific limit is reached;
+- when the Managed heap is almost full, so that the allocation would exceed the amount of memory that can be allocated
+  for Features (i.e. total Managed heap size minus memory reserved for Kernel).
 
 The diagrams below illustrate a Kernel with two Features with various heap configuration scenarios. 
 Kernel reserved memory and Feature memory limits are depicted as contiguous blocks for simplicity.

--- a/KernelDeveloperGuide/kf.rst
+++ b/KernelDeveloperGuide/kf.rst
@@ -722,13 +722,15 @@ By default, the Kernel and Features can allocate without restriction, as long as
 
 The following APIs allow to configure the Managed Heap usage:
 
-- `Kernel.setReservedMemory()`_: Sets the *minimum* amount of memory heap reserved for the Kernel. This is a lower bound: the Kernel may allocate more memory than this reservation if needed.
-- `Feature.setMemoryLimit()`_: Sets the *maximum* amount of memory heap that can be allocated by a Feature. This is an upper bound, not a reservation. 
+- `Kernel.setReservedMemory()`_: Sets the amount of memory heap *reserved* for the Kernel. This is a lower bound: the Kernel may allocate more memory than this reservation if needed.
+- `Feature.setMemoryLimit()`_: Sets the *maximum* amount of memory heap that can be allocated by a Feature. This is an upper bound, not a reservation.
   
-  - Allocation may fail before the memory limit is reached.  
-  - Memory limits of multiple Features can overlap.  
-  - A Feature's memory limit can also overlap with the Kernel’s reserved memory.
+Especially, allocations from Features will fail (throw an OutOfMemoryError):
 
+    - when the feature-specific limit is reached, before the Managed heap is full;
+    - when the Managed heap is full, before the feature-specific limit is reached;
+    - when the Managed heap is almost full, so that the allocation would exceed the amount of memory that can be
+      allocated for Features (i.e. total Managed heap size minus memory reserved for Kernel).
 
 The diagrams below illustrate a Kernel with two Features with various heap configuration scenarios. 
 Kernel reserved memory and Feature memory limits are depicted as contiguous blocks for simplicity.

--- a/KernelDeveloperGuide/kf.rst
+++ b/KernelDeveloperGuide/kf.rst
@@ -729,8 +729,7 @@ Especially, allocations from Features will fail (throw an OutOfMemoryError):
 
 - when the feature-specific limit is reached, before the Managed heap is full;
 - when the Managed heap is full, before the feature-specific limit is reached;
-- when the Managed heap is almost full, so that the allocation would exceed the amount of memory that can be allocated
-  for Features (i.e. total Managed heap size minus memory reserved for Kernel).
+- when the allocation would exceed the amount of memory available to Features (i.e. Managed heap size minus memory reserved for the Kernel).
 
 The diagrams below illustrate a Kernel with two Features with various heap configuration scenarios. 
 Kernel reserved memory and Feature memory limits are depicted as contiguous blocks for simplicity.


### PR DESCRIPTION
The working "overlap" is confusing (especially when reading from top to bottom).
Indeed, the diagrams clarify the meaning of "overlap", but, IMO, the important sentence is "This is an upper bound, not a reservation".

I suggest some rewording to clarify that.

Also, from this documentation, I understand that the features cannot allocate more than what would leave the kernel less than its reserved memory. It is correct?
Another implementation could use the same mechanism than described in the feature criticality section  (with Kernel having some criticality level) but I don't think this is the case, right?