### PR TITLE
Fix default value for the application option 'soar.generate.classnames'

### DIFF
--- a/ApplicationDeveloperGuide/sectionArchitectureOptions.rst
+++ b/ApplicationDeveloperGuide/sectionArchitectureOptions.rst
@@ -20,7 +20,7 @@ Option(checkbox): Embed all type names
 *Description*:
 
 Embed the name of all types. When this option is disabled, only names of
-declared :ref:`required types <section.classpath.elements.types>` are embedded.
+declared :ref:`required types <section.classpath.elements.types>` are embedded. This option affects code size.
 
 .. _enable_group_methods:
 

--- a/ApplicationDeveloperGuide/sectionArchitectureOptions.rst
+++ b/ApplicationDeveloperGuide/sectionArchitectureOptions.rst
@@ -15,12 +15,12 @@ Option(checkbox): Embed all type names
 
 *Option Name*: ``soar.generate.classnames``
 
-*Default value*: ``true``
+*Default value*: ``false``
 
 *Description*:
 
 Embed the name of all types. When this option is disabled, only names of
-declared required types are embedded.
+declared :ref:`required types <section.classpath.elements.types>` are embedded.
 
 .. _enable_group_methods:
 

--- a/ApplicationDeveloperGuide/standaloneApplication.rst
+++ b/ApplicationDeveloperGuide/standaloneApplication.rst
@@ -59,7 +59,7 @@ but all properties files located in this folder are loaded, no matter what their
 To set an option in a properties file, open the file in a text editor and add a line to set the desired option to the desired value, 
 for example::
    
-   soar.generate.classnames=false
+   soar.generate.classnames=true
 
 
 Using System Properties
@@ -69,11 +69,11 @@ Application options can be defined by System properties using the ``microej.opti
 System properties can either be defined in command line using ``-D`` argument, or in ``gradle.properties`` file using ``systemProp.*`` prefix.
 For instance, in command line::
 
-    -Dmicroej.option.soar.generate.classnames=false
+    -Dmicroej.option.soar.generate.classnames=true
 
 or in ``gradle.properties`` file::
 
-   systemProp.microej.option.soar.generate.classnames=false
+   systemProp.microej.option.soar.generate.classnames=true
 
 See the :ref:`sdk_6_howto_gradle_system_property` for more information about System properties.
 
@@ -138,7 +138,7 @@ The figure below shows the expected tree of the ``build`` folder:
 
 It is recommended to index the properties files to your version control system.
 
-To set an option in a properties file, open the file in a text editor and add a line to set the desired option to the desired value. For example: ``soar.generate.classnames=false``.
+To set an option in a properties file, open the file in a text editor and add a line to set the desired option to the desired value. For example: ``soar.generate.classnames=true``.
 
 To use the options declared in properties files in a launcher, perform the following steps:
 

--- a/Trainings/tutorialOptimizeMemoryFootprint.rst
+++ b/Trainings/tutorialOptimizeMemoryFootprint.rst
@@ -265,7 +265,7 @@ Application Configuration
 
 The following application configuration guidelines are recommended in order to minimize the size of the application:
 
-- Disable class names generation by setting the ``soar.generate.classnames`` option to ``false``. Class names are only required when using Java reflection. In such case, the name of a specific class will be embedded only if is explicitly required. See :ref:`stripclassnames` section for more information.
+- Disable class names generation by setting the ``soar.generate.classnames`` option to ``false`` (default). Class names are only required when using Java reflection. In such case, the name of a specific class will be embedded only if is explicitly required. See :ref:`stripclassnames` section for more information.
 - Remove UTF-8 encoding support by setting the ``cldc.encoding.utf8.included`` option to ``false``. The default encoding (``ISO-8859-1``) is enough for most applications.
 - Remove ``SecurityManager`` checks by setting the ``com.microej.library.edc.securitymanager.enabled`` option to ``false``. This feature is only useful for Multi-Sandbox firmwares.
 
@@ -276,14 +276,13 @@ For more information on how to set an option, please refer to the :ref:`define_o
 Stripping Class Names from an Application
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-By default, when a Java class is used, its name is embedded too. A class is used when one of its methods is called, for example.
 Embedding the name of every class is convenient when starting a new MicroEJ Application, but it is rarely necessary and takes a lot of ROM.
 This section explains how to embed only the required class names of an application.
 
 Removing All Class Names
 ^^^^^^^^^^^^^^^^^^^^^^^^
 
-First, the default behavior is inverted by defining the :ref:`Application option <application_options>` ``soar.generate.classnames`` to ``false``.
+First, make sure to set the :ref:`Application option <application_options>` ``soar.generate.classnames`` to ``false`` (default value).
 
 For more information on how to set an option, please refer to the :ref:`define_option` section.
 


### PR DESCRIPTION
We already fixed the application project template: https://github.com/MicroEJ/Tool-Project-Template-Application/pull/24
But I noticed the documentation also was stating the default value is `true`.
I checked and it seems it is not: see scripts/soar.xml

<img width="596" height="113" alt="image" src="https://github.com/user-attachments/assets/e6cc3b4e-ddd9-4840-af35-463fd69dd5b9" />

Maybe this was changed in some Architecture version but I found nothing in the changelog. @frivieremicroej ?